### PR TITLE
Fix Invoice / Client tests.

### DIFF
--- a/lib/Invoice.js
+++ b/lib/Invoice.js
@@ -63,7 +63,7 @@ Invoice.prototype._setXML = function(method, fn) {
                 this.lines.forEach(function(a) {
                   var line = lines.node("line");
                 
-                  for(var key in a) {
+                  for(var key in a && key != "order") {
                     line.node(key).text(a[key]);
                   }
                 });
@@ -143,6 +143,7 @@ Invoice.prototype._getXML = function(xml, fn) {
         break;
         
         case "lines":
+          self.lines = [];
           xml.find("//xmlns:line",this.freshbooks.ns).forEach(function(a) {
             var line = {}
               , a = a.childNodes();


### PR DESCRIPTION
Since updating this library to the latest version for libxmljs,
there have been a few tests that were broken.

The first tests failing had to do with Clients failing when being
added.  I contacted Freshbooks support, and the reason this was
failing was that there was a limit on the
freshbooksjs.freshbooks.com test account.  They removed the Client
creation limit until the end of this month.  I'm going to follow
up with them to see if I can get the test account to be fully
unlimited.

The second issue had to do with a single Invoice test failing.
This seemed to be a two-pronged issue.  The first problem was
that lines on the Invoice were being added (IE one line for the
one added by the user, and another line inserted that came back
from the API).  I manually set the lines to an empty array before
parsing the response XML, which properly sets the lines up
correctly.  The other issue had to do with an error coming back
from the Freshbooks API saying that "order" was an invalid node.
I checked out the Freshbooks API and it seems that Invoice lines
do not contain an "order" field, so I removed it when creating an
XML request to their API.  These two changes fixed the single
Invoice test.

If this PR gets accepted, this should fix #11 (related #12). This
PR should also allow you to release a new version on NPM so that
Node v12.x users can use the library.