### PR TITLE
Seperate loop and key checks.

### DIFF
--- a/lib/Invoice.js
+++ b/lib/Invoice.js
@@ -63,8 +63,10 @@ Invoice.prototype._setXML = function(method, fn) {
                 this.lines.forEach(function(a) {
                   var line = lines.node("line");
                 
-                  for(var key in a && key != "order") {
-                    line.node(key).text(a[key]);
+                  for(var key in a) {
+                    if(key != "order") {
+                      line.node(key).text(a[key]);
+                    }
                   }
                 });
               }


### PR DESCRIPTION
For some reason I had an enviroment who wasn't creating new
Invoice line items.  After some digging I found that the issue
lies with adding the check inside of the for..in loop.  You can
recreate this issue inside of Chrome console with the following
code:

```javascript
var obj = { a: 1, b: 2, c: 3 };

for(var key in obj && key != 'a') { 
  console.log(key, obj[key]);
}
```

Changing the check to be inside the loop fixes this issue.