### PR TITLE
Disregard invoice created_at field

### DIFF
--- a/lib/Invoice.js
+++ b/lib/Invoice.js
@@ -56,6 +56,7 @@ Invoice.prototype._setXML = function(method, fn) {
             case "url":
             case "auth_url":
             case "estimate_id":
+            case "created_at":
             break;
               
             case "lines":


### PR DESCRIPTION
* Disregard invoice created_at field

Failing to disregard this field on update causes the following error: `Error: CANNOT UPDATE INVOICE: Invalid node: created_at.`